### PR TITLE
fix: Update endpoints to limit features

### DIFF
--- a/flagsmith-jira-app/src/IssueFlagPanel.tsx
+++ b/flagsmith-jira-app/src/IssueFlagPanel.tsx
@@ -70,8 +70,8 @@ const IssueFlagForm = ({ features, featureIds, onAdd }: IssueFlagFormProps) => {
 };
 
 type IssueFlagTableProps = {
-  apiKey: string;
   projectUrl: string;
+  apiKey: string;
   environments: EnvironmentModel[];
   features: FeatureModel[];
   featureIds: string[];
@@ -80,13 +80,13 @@ type IssueFlagTableProps = {
 };
 
 const IssueFlagTable = ({
+  projectUrl,
   apiKey,
   environments,
   features,
   featureIds,
   onRemove,
   canEdit,
-  projectUrl,
 }: IssueFlagTableProps) => {
   const [environmentFlags, setEnvironmentFlags] = useState<any>([]);
 
@@ -130,6 +130,7 @@ const IssueFlagTable = ({
   return (
     <Fragment>
       {environmentFlags.map((environmentFlag: FlagModel) => {
+        // add vertical space to separate the previous feature's Remove button from this feature
         const spacer = first ? null : <Text>&nbsp;</Text>;
         first = false;
         return (
@@ -245,7 +246,6 @@ const IssueFlagTable = ({
   );
 };
 
-
 type IssueFlagPanelProps = {
   setError: (error: Error) => void;
   jiraContext: JiraContext;
@@ -301,8 +301,8 @@ const IssueFlagPanel = ({
   return (
     <Fragment>
       <IssueFlagTable
-        apiKey={apiKey}
         projectUrl={projectUrl}
+        apiKey={apiKey}
         environments={environments}
         features={features}
         featureIds={featureIds}

--- a/flagsmith-jira-app/src/IssueFlagPanel.tsx
+++ b/flagsmith-jira-app/src/IssueFlagPanel.tsx
@@ -3,7 +3,7 @@ import ForgeUI, {
   Button,
   ButtonSet,
   Cell,
-  // DateLozenge,
+  DateLozenge,
   Form,
   Fragment,
   Head,
@@ -199,13 +199,18 @@ const IssueFlagTable = ({
                           />
                         </Text>
                       </Cell>
-                    {/* <Cell>
-                      <Text>
-                        <DateLozenge value={new Date(environment.feature.updated_at).getTime()} />
-                      </Text>
-                    </Cell> */}
-                  </Row>
-                );
+                      <Cell>
+                        <Text>{environment.feature_state_value}</Text>
+                      </Cell>
+                      <Cell>
+                        <Text>
+                          <DateLozenge
+                            value={new Date(environment.feature.created_date).getTime()} 
+                          />
+                        </Text>
+                      </Cell>
+                    </Row>
+                  );
                 })}
               </Table>
               {canEdit && (
@@ -221,7 +226,6 @@ const IssueFlagTable = ({
   );
 };
 
-// type Flags = Record<string, FlagModel[]>;
 
 type IssueFlagPanelProps = {
   setError: (error: Error) => void;

--- a/flagsmith-jira-app/src/IssueFlagPanel.tsx
+++ b/flagsmith-jira-app/src/IssueFlagPanel.tsx
@@ -91,19 +91,22 @@ const IssueFlagTable = ({
   const [environmentFlags, setEnvironmentFlags] = useState<any>([]);
 
   useEffect(async () => {
+    // Filtered features by comparing their IDs with the feature IDs stored in Jira.
     const featuresFiltered = features.filter((f) => featureIds.includes(String(f.id)));
     try {
       if (environments.length > 0 && featuresFiltered.length > 0) {
         const featureState: any = {};
+        // Iterate over each filtered feature.
         for (const feature of featuresFiltered) {
+          // Initialize an object to store the state of the feature.
           featureState[String(feature.name)] = {
             name: feature.name,
             feature_id: feature.id,
             description: feature.description,
             environments: [],
           };
-
           for (const environment of environments) {
+            // Obtain the feature states of the filtered features.
             const ffData = await fetchFeatureState({
               apiKey,
               featureName: feature.name,
@@ -111,6 +114,7 @@ const IssueFlagTable = ({
             });
             ffData.name = environment.name;
             ffData.api_key = String(environment.api_key);
+            // Add the feature state data to the feature state object.
             featureState[String(feature.name)].environments.push(ffData);
           }
         }

--- a/flagsmith-jira-app/src/flagsmith.ts
+++ b/flagsmith-jira-app/src/flagsmith.ts
@@ -43,7 +43,7 @@ type PaginatedModels<TModel extends Model> = {
 };
 
 // TODO later: these could be set from environment variables for self-hosted users
-const FLAGSMITH_API_V1 = "https://api.flagsmith.com/api/v1";
+const FLAGSMITH_API_V1 = "https://api.flagsmith.com/api/v1/api/v1";
 export const FLAGSMITH_APP = "https://app.flagsmith.com";
 
 const flagsmithApi = async (
@@ -163,7 +163,7 @@ export const fetchFeatures = async ({
 }): Promise<FeatureModel[]> => {
   checkApiKey(apiKey);
   if (!projectId) throw new ApiError("Flagsmith project not configured", 400);
-  const path = route`/features/get-latest-features/${projectId}/`;
+  const path = route`/features/get-latest-features/${projectId}/?quantity=50`;
   const data = (await flagsmithApi(apiKey, path)) as PaginatedModels<FeatureModel>;
   const results = await unpaginate(apiKey, data);
   if (results.length === 0) throw new ApiError("Flagsmith project has no features", 404);

--- a/flagsmith-jira-app/src/flagsmith.ts
+++ b/flagsmith-jira-app/src/flagsmith.ts
@@ -43,7 +43,7 @@ type PaginatedModels<TModel extends Model> = {
 };
 
 // TODO later: these could be set from environment variables for self-hosted users
-const FLAGSMITH_API_V1 = "https://api.flagsmith.com/api/v1/api/v1";
+const FLAGSMITH_API_V1 = "https://api.flagsmith.com/api/v1";
 export const FLAGSMITH_APP = "https://app.flagsmith.com";
 
 const flagsmithApi = async (
@@ -163,7 +163,7 @@ export const fetchFeatures = async ({
 }): Promise<FeatureModel[]> => {
   checkApiKey(apiKey);
   if (!projectId) throw new ApiError("Flagsmith project not configured", 400);
-  const path = route`/features/get-latest-features/${projectId}/?quantity=50`;
+  const path = route`/projects/${projectId}/features?page_size=50&sort_field=created_date&sort_direction=DESC`;
   const data = (await flagsmithApi(apiKey, path)) as PaginatedModels<FeatureModel>;
   const results = await unpaginate(apiKey, data);
   if (results.length === 0) throw new ApiError("Flagsmith project has no features", 404);

--- a/flagsmith-jira-app/src/flagsmith.ts
+++ b/flagsmith-jira-app/src/flagsmith.ts
@@ -180,7 +180,7 @@ export const fetchFeatures = async ({
 }): Promise<FeatureModel[]> => {
   checkApiKey(apiKey);
   if (!projectId) throw new ApiError("Flagsmith project not configured", 400);
-  const path = route`/projects/${projectId}/features?page_size=50&sort_field=created_date&sort_direction=DESC`;
+  const path = route`/projects/${projectId}/features/`;
   const data = (await flagsmithApi(apiKey, path)) as PaginatedModels<FeatureModel>;
   const results = await unpaginate(apiKey, data);
   if (results.length === 0) throw new ApiError("Flagsmith project has no features", 404);


### PR DESCRIPTION
The function fetchFlags with the endpoint `features/featurestates/?environment=${environmentId};` was changed to fetchFeatureState with the endpoint `/environments/${envAPIKey}/featurestates/?feature_name=${featureName}`.
This change was made to request only the function states of the linked feature, instead of calling all feature states of each environment.

## How to test locally
https://developer.atlassian.com/platform/forge/getting-started/
https://developer.atlassian.com/platform/forge/build-a-hello-world-app-in-jira/