### PR TITLE
fix: error while adding flagsmith property to jira project

### DIFF
--- a/flagsmith-jira-app/src/jira.ts
+++ b/flagsmith-jira-app/src/jira.ts
@@ -71,7 +71,7 @@ const setEntityProperty = async <T>(
     body: JSON.stringify(value),
     jsonResponse: false,
     headers: {
-      Accept: "application/json",
+      "Accept": "application/json",
       "Content-Type": "application/json"
     },
   });

--- a/flagsmith-jira-app/src/jira.ts
+++ b/flagsmith-jira-app/src/jira.ts
@@ -71,8 +71,8 @@ const setEntityProperty = async <T>(
     body: JSON.stringify(value),
     jsonResponse: false,
     headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
+      Accept: 'application/json',
+      "Content-Type": 'application/json'
     },
   });
 };

--- a/flagsmith-jira-app/src/jira.ts
+++ b/flagsmith-jira-app/src/jira.ts
@@ -70,6 +70,10 @@ const setEntityProperty = async <T>(
     method: "PUT",
     body: JSON.stringify(value),
     jsonResponse: false,
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    },
   });
 };
 

--- a/flagsmith-jira-app/src/jira.ts
+++ b/flagsmith-jira-app/src/jira.ts
@@ -71,8 +71,8 @@ const setEntityProperty = async <T>(
     body: JSON.stringify(value),
     jsonResponse: false,
     headers: {
-      Accept: 'application/json',
-      "Content-Type": 'application/json'
+      Accept: "application/json",
+      "Content-Type": "application/json"
     },
   });
 };

--- a/flagsmith-jira-app/src/jira.ts
+++ b/flagsmith-jira-app/src/jira.ts
@@ -72,7 +72,7 @@ const setEntityProperty = async <T>(
     jsonResponse: false,
     headers: {
       "Accept": "application/json",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
     },
   });
 };


### PR DESCRIPTION
### Summary
While trying to setup flagsmith integration on the jira cloud instance, we faced an issue where-in an error was received while adding a flagsmith project in the jira project settings. Further debugging, we found that it gives an error `Unsupported media type 422` while configuring flagsmith in the jira project settings.
Looking at the [documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-properties/#api-rest-api-3-project-projectidorkey-properties-propertykey-put) of jira v3 api, we found that the concerned PUT api call requires the content-type and Accept request headers which were missing. After adding these headers we were able to configure flagsmith for jira cloud successfully.
The PR is to address this problem.