### PR TITLE
ci: rebuild package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9852,9 +9852,9 @@
             }
         },
         "node_modules/elliptic": {
-            "version": "6.5.7",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",


### PR DESCRIPTION
Attempt to resolve dependabot issues like this: 

<img width="927" alt="image" src="https://github.com/user-attachments/assets/01cddc8a-9d22-499b-ae3f-2b543f1d7c9f">

See reasoning [here](https://github.com/dependabot/dependabot-core/issues/6317). 

This PR has been created from me doing the following: 

```bash
rm -rf node_modules/
rm package-lock.json
npm i
```