### PR TITLE
ci: Automate Forge app deployments

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy Forge app
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: GitHub environment and Forge environment to deploy to.
+        type: string
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: flagsmith-jira-app
+    env:
+      FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
+      FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: flagsmith-jira-app/package-lock.json
+
+      - name: Install Forge CLI
+        run: npm install -g @forge/cli@11
+
+      - name: Install app dependencies
+        run: npm ci
+
+      - name: Deploy
+        run: forge deploy --environment ${{ inputs.environment }} --non-interactive

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: flagsmith-jira-app
     env:
-      FORGE_EMAIL: ${{ secrets.FORGE_EMAIL }}
+      FORGE_EMAIL: ${{ vars.FORGE_EMAIL }}
       FORGE_API_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install -g npm@11
 
       - name: Install Forge CLI
-        run: npm install -g @forge/cli@11
+        run: npm install -g @forge/cli@12
 
       - name: Opt out of Forge usage analytics
         run: forge settings set usage-analytics false

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -28,6 +28,9 @@ jobs:
           cache: npm
           cache-dependency-path: flagsmith-jira-app/package-lock.json
 
+      - name: Upgrade npm
+        run: npm install -g npm@11
+
       - name: Install Forge CLI
         run: npm install -g @forge/cli@11
 

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Forge CLI
         run: npm install -g @forge/cli@11
 
+      - name: Opt out of Forge usage analytics
+        run: forge settings set usage-analytics false
+
       - name: Install app dependencies
         run: npm ci
 

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -6,7 +6,36 @@ on:
       - main
 
 jobs:
+  authorize:
+    name: Check actor has repo write access
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          if [[ "$ACTOR" == *"[bot]"* ]]; then
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping deploy: $ACTOR is a bot."
+            exit 0
+          fi
+          permission=$(gh api "/repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null) || permission=none
+          case "$permission" in
+            admin | maintain | write)
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping deploy: $ACTOR has permission '$permission'."
+              ;;
+          esac
+
   deploy:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     uses: ./.github/workflows/_deploy.yml
     with:
       environment: development

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,0 +1,13 @@
+name: Deploy to development
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      environment: development
+    secrets: inherit

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -4,38 +4,10 @@ on:
   push:
     branches-ignore:
       - main
+      - dependabot/**
 
 jobs:
-  authorize:
-    name: Check actor has repo write access
-    runs-on: ubuntu-latest
-    outputs:
-      authorized: ${{ steps.check.outputs.authorized }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          if [[ "$ACTOR" == *"[bot]"* ]]; then
-            echo "authorized=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping deploy: $ACTOR is a bot."
-            exit 0
-          fi
-          permission=$(gh api "/repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null) || permission=none
-          case "$permission" in
-            admin | maintain | write)
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "authorized=false" >> "$GITHUB_OUTPUT"
-              echo "::notice::Skipping deploy: $ACTOR has permission '$permission'."
-              ;;
-          esac
-
   deploy:
-    needs: authorize
-    if: needs.authorize.outputs.authorized == 'true'
     uses: ./.github/workflows/_deploy.yml
     with:
       environment: development

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,13 @@
+name: Deploy to production
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      environment: production
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,13 @@
+name: Deploy to staging
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/_deploy.yml
+    with:
+      environment: staging
+    secrets: inherit

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "flagsmith-jira-app": "1.1.7"
+}

--- a/flagsmith-jira-app/package-lock.json
+++ b/flagsmith-jira-app/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.2.0"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "@types/react": "^18.3.19"
       }
     },
@@ -11662,6 +11663,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -14328,6 +14339,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unzipit": {

--- a/flagsmith-jira-app/package.json
+++ b/flagsmith-jira-app/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "@types/react": "^18.3.19"
   }
 }

--- a/flagsmith-jira-app/tsconfig.json
+++ b/flagsmith-jira-app/tsconfig.json
@@ -1,6 +1,12 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "types": ["node"],
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "strict": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,62 @@
+{
+  "bootstrap-sha": "9bb2775b761e2d7479a99ec69358b49acf8ed39d",
+  "packages": {
+    "flagsmith-jira-app": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "include-component-in-tag": false
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "hidden": false,
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "hidden": false,
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "ci",
+      "hidden": false,
+      "section": "CI"
+    },
+    {
+      "type": "docs",
+      "hidden": false,
+      "section": "Docs"
+    },
+    {
+      "type": "deps",
+      "hidden": false,
+      "section": "Dependency Updates"
+    },
+    {
+      "type": "perf",
+      "hidden": false,
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "refactor",
+      "hidden": false,
+      "section": "Refactoring"
+    },
+    {
+      "type": "test",
+      "hidden": false,
+      "section": "Tests"
+    },
+    {
+      "type": "chore",
+      "hidden": false,
+      "section": "Other"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds release-please config tracking `flagsmith-jira-app` (bootstrapped at `1.1.7`).
- Adds three deployment workflows (development on non-`main` push, staging on `main` push, production on `v*` tag) sharing a reusable workflow.
- Pins Forge CLI to v12 (the README's v11 was emitting a deprecation warning).
- Fixes `flagsmith-jira-app/tsconfig.json`: was missing `target`/`lib`/`module`/`moduleResolution`/`types`, so the Forge bundler rejected modern JS features (`Promise`, `Set`, `Array.includes`, `process`). Also adds `skipLibCheck` and `@types/node`.

Requires GitHub Environment `development` with `FORGE_EMAIL` (var) and `FORGE_API_TOKEN` (secret). Staging and production environments to be added similarly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)