### PR TITLE
chore: Add CHANGELOG to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 package.json
 package-lock.json
+
+flagsmith-jira-app/CHANGELOG.md


### PR DESCRIPTION
Adds flagsmith-jira-app/CHANGELOG.md to prettier ignore since it's fully managed by release-please (which outputs whitespace that prettier doesn't like). 