### PR TITLE
deps: bump minimatch to fix ReDoS (CVE-2026-27903)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -689,9 +689,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2629,13 +2629,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"

--- a/package.json
+++ b/package.json
@@ -9,5 +9,10 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^3.1.0",
         "typescript": "^4.8.4"
+    },
+    "overrides": {
+        "@typescript-eslint/typescript-estree": {
+            "minimatch": "^9.0.7"
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Resolves [dependabot alert #58](https://github.com/Flagsmith/flagsmith-jira-integration/security/dependabot/58) — high-severity ReDoS in `minimatch` (GHSA-7r86-cg39-jmmj / CVE-2026-27903).
- `minimatch@9.0.3` pulled in transitively by `@typescript-eslint/typescript-estree` is replaced via an `npm overrides` entry pinning it to `^9.0.7` (resolved to `9.0.9`).
- Scoped override so unrelated `minimatch@3.x` consumers are untouched.

## Test plan
- [x] `npm install --package-lock-only` regenerates the lock with `minimatch@9.0.9` under `@typescript-eslint/typescript-estree`
- [x] `npm ls minimatch` shows no `invalid` entries
- [x] `npx eslint .` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)