### PR TITLE
fix(deps): restore @forge/api as a direct dependency

### DIFF
--- a/flagsmith-jira-app/package-lock.json
+++ b/flagsmith-jira-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "flagsmith-jira-app",
       "version": "1.1.8",
       "dependencies": {
+        "@forge/api": "5.2.0",
         "@forge/bridge": "4.4.1",
         "@forge/react": "12.0.0",
         "@forge/resolver": "1.8.0",
@@ -5330,6 +5331,38 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@forge/api": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@forge/api/-/api-5.2.0.tgz",
+      "integrity": "sha512-Kc0qzqccviRqC0Nj0pFhzEi7G6duQRicYUERLy6IwR0ETBGJx6VCFqHbKRKT8ZxpEhTSBp9NItLuV7ayBXGBew==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@forge/auth": "0.0.7",
+        "@forge/egress": "1.4.0",
+        "@forge/i18n": "0.0.5",
+        "@forge/storage": "1.8.0",
+        "@forge/util": "1.4.8",
+        "headers-utils": "^3.0.2"
+      }
+    },
+    "node_modules/@forge/api/node_modules/@forge/i18n": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@forge/i18n/-/i18n-0.0.5.tgz",
+      "integrity": "sha512-G4M8NTXbNR5HzpYNFQMczypUuxoItdtAMQmwIgUkzE2osrjPRKhFx/VniMGnnXoowgmDLoaMtMcllvxcm/YnVA==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@forge/auth": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@forge/auth/-/auth-0.0.7.tgz",
+      "integrity": "sha512-9wzbl7FoaTZsVXuBI6F4O9TWRucpM76WILKoimGSK/1n6JMiai0QHBmBJLAon8jO/MmTJSHPxLE48UjR+J2s7Q==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@forge/bridge": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@forge/bridge/-/bridge-4.4.1.tgz",
@@ -5339,6 +5372,15 @@
         "@atlaskit/tokens": "^1.58.0",
         "@forge/i18n": "0.0.3",
         "@types/history": "^4.7.11"
+      }
+    },
+    "node_modules/@forge/egress": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@forge/egress/-/egress-1.4.0.tgz",
+      "integrity": "sha512-7Jrjq6kgF32yI4kqSmXz6z6ac9zOyrEn3NEq4jDUZ2eAq/qn0UugE/+9t7MlEd1jsz94hY9utezwjqkRc1qKwQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "minimatch": "^9.0.3"
       }
     },
     "node_modules/@forge/i18n": {
@@ -5511,6 +5553,18 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@forge/resolver/-/resolver-1.8.0.tgz",
       "integrity": "sha512-n9u8zAijT+MQLogo72xplFLZzcM7BDhQ9tW7qYZFS58/ZHtju76rVupBzSReeCxvo5lL2JTXB9mnFh2N8p2xyw==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@forge/storage": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@forge/storage/-/storage-1.8.0.tgz",
+      "integrity": "sha512-xDHyrXKZ10r99vXsWmuD7+AUFWrptyAi8HFk+97froly6MDKT4V1zgV/0eV8fOCVKz9GX+HiGZNTnCjzpGqKxA==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
+    "node_modules/@forge/util": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@forge/util/-/util-1.4.8.tgz",
+      "integrity": "sha512-5D3E2W6j4VzNet2X98It8GRfOJFAkAI/eyCz1VFOX2BzYBMFofuyHr4/PDDpan/I6MnYtSdamlC8P7Q/B3OJDg==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5774,6 +5828,12 @@
         "npm": ">=6"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/bind-event-listener": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
@@ -5791,6 +5851,15 @@
       "resolved": "https://registry.npmjs.org/bowser-ultralight/-/bowser-ultralight-1.0.6.tgz",
       "integrity": "sha512-ASWi8n3c6JvsUhbjproHnT4Mdhs4Q9wOxq1oSjUkM2e5StEEUmy1ej4UNOLSyeU4ANQFTx+mY+bsv/aH+AIcpg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -6232,6 +6301,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/headers-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-3.0.2.tgz",
+      "integrity": "sha512-xAxZkM1dRyGV2Ou5bzMxBPNLoRCjcX+ya7KSWybQD2KwLphxsapUVK6x/02o7f4VU6GPSXch9vNY2+gkU8tYWQ==",
+      "license": "MIT"
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -6490,6 +6565,21 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minipass": {

--- a/flagsmith-jira-app/package.json
+++ b/flagsmith-jira-app/package.json
@@ -8,6 +8,7 @@
     "format": "prettier src/* --write"
   },
   "dependencies": {
+    "@forge/api": "5.2.0",
     "@forge/bridge": "4.4.1",
     "@forge/react": "12.0.0",
     "@forge/resolver": "1.8.0",


### PR DESCRIPTION
Fixes the forge bundling failure that has been breaking deployments since #60.

`@forge/api` was previously satisfied as a transitive dependency of `@forge/resolver@1.6.10`. The bump to `1.8.0` in #60 dropped it, but there are direct imports in the code. This PR adds it back as a direct dependency. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)