### PR TITLE
fix: a warning doesn't pop up when no features exist in connected projects

### DIFF
--- a/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
+++ b/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
@@ -124,16 +124,15 @@ const IssueFeaturesPanel = ({ setError }: WrappableComponentProps): JSX.Element 
     }
   };
 
+  // note: undefined means still loading; empty arrays mean loaded but no data,
+  // which is reported to the user by the form rather than shown as loading
   const ready =
     extension !== undefined &&
     projectIds !== undefined &&
     projectIds.length > 0 &&
     featureIds !== undefined &&
     environments !== undefined &&
-    environmentsFeatures !== undefined &&
-    environmentsFeatures.length > 0 &&
-    environmentsFeatures[0] !== undefined &&
-    environmentsFeatures[0].length > 0;
+    environmentsFeatures !== undefined;
 
   return ready ? (
     <Fragment>


### PR DESCRIPTION
NOTE: don't review yet, testing deploying to dev