### PR TITLE
fix: when connected project(s) don't have any features a loading spinner pops up instead of warning

### DIFF
--- a/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
+++ b/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
@@ -124,16 +124,15 @@ const IssueFeaturesPanel = ({ setError }: WrappableComponentProps): JSX.Element 
     }
   };
 
+  // note: undefined means still loading; empty arrays mean loaded but no data,
+  // which is reported to the user by the form rather than shown as loading
   const ready =
     extension !== undefined &&
     projectIds !== undefined &&
     projectIds.length > 0 &&
     featureIds !== undefined &&
     environments !== undefined &&
-    environmentsFeatures !== undefined &&
-    environmentsFeatures.length > 0 &&
-    environmentsFeatures[0] !== undefined &&
-    environmentsFeatures[0].length > 0;
+    environmentsFeatures !== undefined;
 
   return ready ? (
     <Fragment>

--- a/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
+++ b/flagsmith-jira-app/src/frontend/components/IssueFeaturesPanel.tsx
@@ -124,8 +124,7 @@ const IssueFeaturesPanel = ({ setError }: WrappableComponentProps): JSX.Element 
     }
   };
 
-  // note: undefined means still loading; empty arrays mean loaded but no data,
-  // which is reported to the user by the form rather than shown as loading
+
   const ready =
     extension !== undefined &&
     projectIds !== undefined &&


### PR DESCRIPTION
Bug: When a user connects a project(s) which doesn't have any features and goes into a Jira ticket the features dropdown is stuck in the loading state instead of showing a warning.

Fix: Change the condition which displays the loading spinner.

Verified in the dev environment in Jira.